### PR TITLE
Prevent crash (`NRE`) when merge'd BOM has no components.

### DIFF
--- a/src/cyclonedx/Commands/MergeCommand.cs
+++ b/src/cyclonedx/Commands/MergeCommand.cs
@@ -93,7 +93,7 @@ namespace CycloneDX.Cli.Commands
             if (!outputToConsole)
             {
                 Console.WriteLine("Writing output file...");
-                Console.WriteLine($"    Total {outputBom.Components.Count} components");
+                Console.WriteLine($"    Total {outputBom.Components?.Count ?? 0} components");
             }
 
             return await CliUtils.OutputBomHelper(outputBom, options.OutputFormat, options.OutputFile).ConfigureAwait(false);


### PR DESCRIPTION
When the `merge` output BOM has no components, the program currently crashes with:

```
Processing input file bom-empty-1.xml
Processing input file bom-empty-2.xml
Writing output file...
Unhandled exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at CycloneDX.Cli.Commands.MergeCommand.Merge(MergeCommandOptions options)
   at System.CommandLine.Invocation.CommandHandler.GetExitCodeAsync(Object value, InvocationContext context)
   at System.CommandLine.Invocation.ModelBindingCommandHandler.InvokeAsync(InvocationContext context)
   at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInvocationChain>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass23_0.<<UseParseErrorReporting>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass16_0.<<UseHelp>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass27_0.<<UseVersionOption>b__1>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass25_0.<<UseTypoCorrections>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseSuggestDirective>b__24_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass22_0.<<UseParseDirective>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass11_0.<<UseDebugDirective>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<RegisterWithDotnetSuggest>b__10_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass14_0.<<UseExceptionHandler>b__0>d.MoveNext()
```

As a workaround, avoid `NullReferenceException` when printing the output component count, by defaulting to `0` when `outputBom.Components` is null. 

Fixes #208.