### PR TITLE
Add support for `osx-arm64` runtime

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        runtime: [linux-x64, linux-musl-x64, linux-arm, linux-arm64, win-x64, win-x86, win-arm, win-arm64, osx-x64]
+        runtime: [linux-x64, linux-musl-x64, linux-arm, linux-arm64, win-x64, win-x86, win-arm, win-arm64, osx-x64, osx-arm64]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           REPO=cyclonedx/cyclonedx-cli
           dotnet build --configuration Release
           mkdir bin
-          for runtime in linux-x64 linux-musl-x64 linux-arm linux-arm64 win-x64 win-x86 win-arm win-arm64 osx-x64
+          for runtime in linux-x64 linux-musl-x64 linux-arm linux-arm64 win-x64 win-x86 win-arm win-arm64 osx-x64 osx-arm64
           do
             dotnet publish src/cyclonedx/cyclonedx.csproj -r $runtime --configuration Release /p:Version=$VERSION --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesInSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true --output bin/$runtime
           done
@@ -159,4 +159,14 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: bin/osx-x64/cyclonedx
           asset_name: cyclonedx-osx-x64
+          asset_content_type: application/octet-stream
+
+      - name: Upload binary to github release
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bin/osx-arm64/cyclonedx
+          asset_name: cyclonedx-osx-arm64
           asset_content_type: application/octet-stream

--- a/src/cyclonedx/cyclonedx.csproj
+++ b/src/cyclonedx/cyclonedx.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <PublishTrimmed>true</PublishTrimmed>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <RuntimeIdentifiers>linux-x64;linux-musl-x64;linux-arm;linux-arm64;win-x64;win-x86;win-arm;win-arm64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>linux-x64;linux-musl-x64;linux-arm;linux-arm64;win-x64;win-x86;win-arm;win-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/cyclonedx/packages.lock.json
+++ b/src/cyclonedx/packages.lock.json
@@ -343,6 +343,43 @@
         }
       }
     },
+    "net6.0/osx-arm64": {
+      "System.IO.FileSystem.AccessControl": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "SxHB3nuNrpptVk+vZ/F+7OHEpoHUIKKMl02bUmYHQr1r+glbZQxs7pRtsf4ENO29TVm2TH3AEeep2fJcy92oYw==",
+        "dependencies": {
+          "System.Security.AccessControl": "5.0.0",
+          "System.Security.Principal.Windows": "5.0.0"
+        }
+      },
+      "System.Security.AccessControl": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "AUADIc0LIEQe7MzC+I0cl0rAT8RrTAKFHl53yHjEUzNVIaUlhFY11vc2ebiVJzVBuOzun6F7FBA+8KAbGTTedQ=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "elM3x+xSRhzQysiqo85SbidJJ2YbZlnvmh+53TuSZHsD7dNuuEWser+9EFtY+rYupBwkq2avc6ZCO3/6qACgmg==",
+        "dependencies": {
+          "System.Formats.Asn1": "6.0.0"
+        }
+      },
+      "System.Security.Principal.Windows": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "t0MGLukB5WAVU9bO3MGzvlGnyJPgUlcwerXn1kzBRjwLKixT96XV0Uza41W49gVd8zEMFu9vQEFlv0IOrytICA=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      }
+    },
     "net6.0/osx-x64": {
       "System.IO.FileSystem.AccessControl": {
         "type": "Transitive",


### PR DESCRIPTION
.NET 6 [introduced](https://devblogs.microsoft.com/dotnet/announcing-net-6/#arm64-support) native arm64 support for macOS.
It'd be awesome if we could distribute official builds for the `osx-arm64` runtime as well.

I remember that there was an issue being discussed regarding this a few months (a year?) back in the CDX Slack, but I can't find that thread anymore. Apologies if this issue still persists. But it may just be that .NET 6 fixed it.