### PR TITLE
Populate meta-data based on merge from first input BOM

### DIFF
--- a/src/cyclonedx/Commands/MergeCommand.cs
+++ b/src/cyclonedx/Commands/MergeCommand.cs
@@ -81,10 +81,23 @@ namespace CycloneDX.Cli.Commands
             else
             {
                 outputBom = CycloneDXUtils.FlatMerge(inputBoms);
+                if (outputBom.Metadata is null) outputBom.Metadata = new Metadata();
                 if (bomSubject != null)
                 {
-                    if (outputBom.Metadata is null) outputBom.Metadata = new Metadata();
+                    // use the params provided if possible
                     outputBom.Metadata.Component = bomSubject;
+                }
+                else
+                {
+                    // otherwise use the first non-null component from the input BOMs as the default
+                    foreach (var bom in inputBoms)
+                    {
+                        if(bom.Metadata != null && bom.Metadata.Component != null)
+                        {
+                            outputBom.Metadata.Component = bom.Metadata.Component;
+                            break;
+                        }
+                    }
                 }
             }
 

--- a/tests/cyclonedx.tests/MergeTests.cs
+++ b/tests/cyclonedx.tests/MergeTests.cs
@@ -65,9 +65,9 @@ namespace CycloneDX.Cli.Tests
                 {
                     options.InputFiles.Add(Path.Combine("Resources", "Merge", inputFilename));
                 }
-                
+
                 var exitCode = await MergeCommand.Merge(options).ConfigureAwait(false);
-                
+
                 Assert.Equal(0, exitCode);
                 var bom = File.ReadAllText(fullOutputPath);
                 Snapshot.Match(bom, SnapshotNameExtension.Create(hierarchical ? "Hierarchical" : "Flat", snapshotInputFilenames, inputFormat, outputFilename, outputFormat));

--- a/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.json_sbom2.json_autodetect_sbom.json_autodetect.snap
+++ b/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.json_sbom2.json_autodetect_sbom.json_autodetect.snap
@@ -2,6 +2,13 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "name": "thing1",
+      "version": "1"
+    }
+  },
   "components": [
     {
       "type": "library",

--- a/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.json_sbom2.json_autodetect_sbom.json_json.snap
+++ b/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.json_sbom2.json_autodetect_sbom.json_json.snap
@@ -2,6 +2,13 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "name": "thing1",
+      "version": "1"
+    }
+  },
   "components": [
     {
       "type": "library",

--- a/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.json_sbom2.json_autodetect_sbom.xml_autodetect.snap
+++ b/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.json_sbom2.json_autodetect_sbom.xml_autodetect.snap
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <bom xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1" xmlns="http://cyclonedx.org/schema/bom/1.4">
+  <metadata>
+    <component type="application">
+      <name>thing1</name>
+      <version>1</version>
+    </component>
+  </metadata>
   <components>
     <component type="library">
       <name>acme-library</name>

--- a/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.json_sbom2.json_autodetect_sbom.xml_xml.snap
+++ b/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.json_sbom2.json_autodetect_sbom.xml_xml.snap
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <bom xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1" xmlns="http://cyclonedx.org/schema/bom/1.4">
+  <metadata>
+    <component type="application">
+      <name>thing1</name>
+      <version>1</version>
+    </component>
+  </metadata>
   <components>
     <component type="library">
       <name>acme-library</name>

--- a/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.json_sbom2.json_json_sbom.json_autodetect.snap
+++ b/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.json_sbom2.json_json_sbom.json_autodetect.snap
@@ -2,6 +2,13 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "name": "thing1",
+      "version": "1"
+    }
+  },
   "components": [
     {
       "type": "library",

--- a/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.json_sbom2.xml_autodetect_sbom.xml_autodetect.snap
+++ b/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.json_sbom2.xml_autodetect_sbom.xml_autodetect.snap
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <bom xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1" xmlns="http://cyclonedx.org/schema/bom/1.4">
+  <metadata>
+    <component type="application">
+      <name>thing1</name>
+      <version>1</version>
+    </component>
+  </metadata>
   <components>
     <component type="library">
       <name>acme-library</name>

--- a/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.xml_sbom2.xml_autodetect_sbom.json_autodetect.snap
+++ b/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.xml_sbom2.xml_autodetect_sbom.json_autodetect.snap
@@ -2,6 +2,14 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
+  "metadata": {
+    "component": {
+      "type": "application",
+      "name": "thing1",
+      "version": "1",
+      "licenses": []
+    }
+  },
   "components": [
     {
       "type": "library",

--- a/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.xml_sbom2.xml_autodetect_sbom.xml_autodetect.snap
+++ b/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.xml_sbom2.xml_autodetect_sbom.xml_autodetect.snap
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <bom xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1" xmlns="http://cyclonedx.org/schema/bom/1.4">
+  <metadata>
+    <component type="application">
+      <name>thing1</name>
+      <version>1</version>
+    </component>
+  </metadata>
   <components>
     <component type="library">
       <name>acme-library</name>

--- a/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.xml_sbom2.xml_xml_sbom.xml_autodetect.snap
+++ b/tests/cyclonedx.tests/__snapshots__/MergeTests.Merge_Flat_sbom1.xml_sbom2.xml_xml_sbom.xml_autodetect.snap
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <bom xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1" xmlns="http://cyclonedx.org/schema/bom/1.4">
+  <metadata>
+    <component type="application">
+      <name>thing1</name>
+      <version>1</version>
+    </component>
+  </metadata>
   <components>
     <component type="library">
       <name>acme-library</name>


### PR DESCRIPTION
Ahoy,

I've been looking through the open issues and found #218 & #153 which report similar problems to what I'm facing, so I've raised a PR to have a conversation around.

My only (current) use case for the CLI tool is to merge two of my BOMs together, one produced by the Maven plugin detailing the Java dependencies and the other from another tool for apks and the like at the distro level of my docker images.

The problem is that when merging them into a flat BOM, outside of the tool information, the meta-data is not merged and I'm left with incomplete information. I can see there's the ability to provide certain meta-data information via the CLI, but there's nothing for the bom-ref. Downstream this means that when I push my BOMs to Dependency Track I no longer have my dependency graph available, as [it depends on it to identify the top-most dependency](https://github.com/DependencyTrack/dependency-track/blob/fddf75834b93028afe59efea6bcf1fc0ae057757/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java#L619).

Steve's idea in #153 of using one of the BOMs as the basis for the metadata was the same solution I had in mind, only rather than adding a new argument to specify which I've instead just opted to treat the first non-null one as the source of truth. If implemented this should help with [DependencyTrack/dependency-track/#1559](https://github.com/DependencyTrack/dependency-track/issues/1559).

