### PR TITLE
Dockerfile: add path containing cyclonedx to PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0
 
+ENV PATH=/:$PATH
+
 COPY bin/linux-x64/cyclonedx /cyclonedx
 
 ADD https://github.com/tomnomnom/gron/releases/download/v0.6.1/gron-linux-amd64-0.6.1.tgz /tmp/gron.tgz


### PR DESCRIPTION
Allows the cyclonedx command to be more easily used when running the image with an entrypoint.

For example, when running:
```
docker run -w /app -v "$(pwd)":/app:Z -it --entrypoint /bin/bash cyclonedx/cyclonedx-cli:0.24.0
```
it's nice to be able to use the "cyclonedx" command instead of having to give an absolute path ("/cyclonedx").

Discovered while working to improve GitLab's documentation for this tool in https://gitlab.com/gitlab-org/gitlab/-/merge_requests/98357