### PR TITLE
Fixes error in add command if base path contains no trailing separator

### DIFF
--- a/src/cyclonedx/Commands/Add/AddFilesCommand.cs
+++ b/src/cyclonedx/Commands/Add/AddFilesCommand.cs
@@ -83,7 +83,9 @@ namespace CycloneDX.Cli.Commands.Add
             {
                 options.BasePath = Directory.GetCurrentDirectory();
             }
+
             options.BasePath = Path.GetFullPath(options.BasePath);
+            if (!Path.EndsInDirectorySeparator(options.BasePath)) options.BasePath += Path.DirectorySeparatorChar;
 
             if (!outputToConsole) Console.WriteLine($"Processing base path {options.BasePath}");
 
@@ -114,17 +116,16 @@ namespace CycloneDX.Cli.Commands.Add
             if (files.Count > 0)
             {
                 if (bom.Components == null) bom.Components = new List<Component>();
-            
+
                 var existingFiles = bom.Components.Where<Component>(component => component.Type == Component.Classification.File);
 
                 foreach (var file in files)
                 {
-                    // Ant file names are prefixed with "/"
-                    var baseFilename = file.StartsWith("/", false, CultureInfo.InvariantCulture) ? file.Substring(1) : file;
+                    var baseFilename = Path.GetFileName(file);
                     if (!existingFiles.Any<Component>(component => component.Name == baseFilename))
                     {
                         if (!outputToConsole) Console.WriteLine($"Adding file {baseFilename}");
-                        var fullPath = Path.Combine(options.BasePath, baseFilename);
+                        var fullPath = Path.Combine(options.BasePath, file);
                         var fileComponent = new Component
                         {
                             Type = Component.Classification.File,


### PR DESCRIPTION
When debugging the issue described in #206 I discovered that the issue is resolved by adding a trailing path separator to the base path. 
Additionally, the AntPath won´t start with any leading separator, if the search path has a trailing separator. In code there was a handling for a leading `/`, however, on a windows based system it was a `\` in my case. This should be obsolete now.

Instead, the relative path is now being removed from the name entry in the BOM. I don´t know if my understanding is correct, but the BOM should only specify its name, not the path I think.

Example:
base path: `C:\BasePath` -> corrected by code to `C:\BasePath\`. 
file: `C:\BasePath\SubDir\dep.dll` -> before the bom name entry was `SubDir\dep.dll` now only is `dep.dll`.