### PR TITLE
Removed trimming of binaries

### DIFF
--- a/src/cyclonedx/cyclonedx.csproj
+++ b/src/cyclonedx/cyclonedx.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <PublishTrimmed>true</PublishTrimmed>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <RuntimeIdentifiers>linux-x64;linux-musl-x64;linux-arm;linux-arm64;win-x64;win-x86;win-arm;win-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
   </PropertyGroup>


### PR DESCRIPTION
The CLI was unable to sign XML BOMs as can be seen in: https://github.com/CycloneDX/cyclonedx-cli/issues/251

This is caused by the trimming of binaries; when publishing the binary, the build will cause several IL2026 warnings in the crypto library and xml library. According to ,https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/fixing-warnings , this warning denotes: "This attribute is used when code is fundamentally not trim compatible, or the trim dependency is too complex to explain to the trimmer. "

More information can be seen here: https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2026

Therefore, I think that trimming should be disabled to ensure proper working of the tool.