### PR TITLE
Fix truncating pre-existing output file when overwritten

### DIFF
--- a/src/cyclonedx/CliUtils.cs
+++ b/src/cyclonedx/CliUtils.cs
@@ -154,7 +154,7 @@ namespace CycloneDX.Cli
                 }
             }
 
-            using var stream = filename == null ? Console.OpenStandardOutput() : new FileStream(filename, FileMode.Create);
+            using var stream = filename == null ? Console.OpenStandardOutput() : File.Create(filename);
 
             switch (format)
             {
@@ -193,7 +193,7 @@ namespace CycloneDX.Cli
 
             bom.SpecVersion = outputVersion.HasValue ? outputVersion.Value : SpecificationVersionHelpers.CurrentVersion;
 
-            using var stream = filename == null ? Console.OpenStandardOutput() : File.OpenWrite(filename);
+            using var stream = filename == null ? Console.OpenStandardOutput() : File.Create(filename);
 
             switch (format)
             {

--- a/src/cyclonedx/CliUtils.cs
+++ b/src/cyclonedx/CliUtils.cs
@@ -154,7 +154,7 @@ namespace CycloneDX.Cli
                 }
             }
 
-            using var stream = filename == null ? Console.OpenStandardOutput() : File.OpenWrite(filename);
+            using var stream = filename == null ? Console.OpenStandardOutput() : new FileStream(filename, FileMode.Create);
 
             switch (format)
             {


### PR DESCRIPTION
Fix truncating pre-existing output file when overwritten

Closes: https://github.com/CycloneDX/cyclonedx-cli/issues/255
Closes: https://github.com/CycloneDX/cyclonedx-cli/issues/329