### PR TITLE
CliUtils.OutputBomHelper(): use File.Create() to truncate an existing…

### DIFF
--- a/src/cyclonedx/CliUtils.cs
+++ b/src/cyclonedx/CliUtils.cs
@@ -154,7 +154,7 @@ namespace CycloneDX.Cli
                 }
             }
 
-            using var stream = filename == null ? Console.OpenStandardOutput() : File.OpenWrite(filename);
+            using var stream = filename == null ? Console.OpenStandardOutput() : File.Create(filename);
 
             switch (format)
             {


### PR DESCRIPTION
… output file

Closes: #329
Closes: #255
