### PR TITLE
MergeCommand: use Bom.BomMetadataUpdate()…

### DIFF
--- a/src/cyclonedx/Commands/MergeCommand.cs
+++ b/src/cyclonedx/Commands/MergeCommand.cs
@@ -101,8 +101,12 @@ namespace CycloneDX.Cli.Commands
                 }
             }
 
-            outputBom.Version = 1;
-            outputBom.SerialNumber = "urn:uuid:" + System.Guid.NewGuid().ToString();
+            // Ensure that the new merged document has its own identity
+            // (new SerialNumber, Version=1, Timestamp...) and its Tools
+            // collection refers to this library and the program/tool
+            // like cyclonedx-cli which consumes it:
+            outputBom.BomMetadataUpdate(true);
+            outputBom.BomMetadataReferThisToolkit();
 
             if (!outputToConsole)
             {


### PR DESCRIPTION
…and BomMetadataReferThisToolkit() methods in OOP fashion

Depends on library changes from https://github.com/CycloneDX/cyclonedx-dotnet-library/pull/256
* No idea how to facilitate this with C# recipes to pass CI before that PR gets merged...
