### PR TITLE
Overwrite existing files when a new SBOM is saved

### DIFF
--- a/src/cyclonedx/CliUtils.cs
+++ b/src/cyclonedx/CliUtils.cs
@@ -1,4 +1,4 @@
-// This file is part of CycloneDX CLI Tool
+﻿// This file is part of CycloneDX CLI Tool
 //
 // Licensed under the Apache License, Version 2.0 (the “License”);
 // you may not use this file except in compliance with the License.
@@ -154,7 +154,7 @@ namespace CycloneDX.Cli
                 }
             }
 
-            using var stream = filename == null ? Console.OpenStandardOutput() : File.OpenWrite(filename);
+            using var stream = filename == null ? Console.OpenStandardOutput() : File.Create(filename);
 
             switch (format)
             {


### PR DESCRIPTION
A change is made so when a new SBOM is produced it overwrites any existing file with the same name. This change is introduced due to the current behavior which simply writes the bytes to the same file, so if the previous files length was longer, that content would still remain. Leading to an invalid SBOM being created by the CLI.