### PR TITLE
Add OCI image annotation, sbom, provenance to docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           do
             dotnet publish src/cyclonedx/cyclonedx.csproj -r $runtime --configuration Release /p:Version=$VERSION --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesInSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true --output bin/$runtime
           done
-          docker build -f Dockerfile --build-arg VERSION=$VERSION -t $REPO:$VERSION -t $REPO:latest .
+          docker build --sbom=true --provenance mode=max,builder-id="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" --annotation "org.opencontainers.image.url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" --annotation "org.opencontainers.image.source=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" --annotation "org.opencontainers.image.version=$VERSION" --annotation "org.opencontainers.image.revision=$GITHUB_SHA" --annotation "org.opencontainers.image.created=$(date -Iseconds)" -f Dockerfile --build-arg VERSION=$VERSION -t $REPO:$VERSION -t $REPO:latest .
 
       - name: Publish Docker image to Docker Hub
         env:


### PR DESCRIPTION
These annotations are useful for people to use manually and for use by tools. For example, Snyk uses them in its UI and Renovate uses them to find release notes.

The provenance attestations include facts about the build process, including details such as:
* Build timestamps
* Build parameters and environment
* Version control metadata
* Source code details
* Materials (files, scripts) consumed during the build

See:
* https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
* https://snyk.io/blog/how-and-when-to-use-docker-labels-oci-container-annotations/
* https://github.com/renovatebot/renovate/blob/34.115.1/lib/modules/datasource/docker/readme.md
* https://docs.docker.com/build/attestations/slsa-provenance/
* https://docs.docker.com/build/attestations/slsa-definitions/
* https://docs.docker.com/build/attestations/sbom/