### PR TITLE
Switch to .NET 8

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-dotnet@v3.0.2
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '8.0'
 
       - name: Build
         run: dotnet build /WarnAsError
@@ -31,20 +31,20 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        runtime: [linux-x64, linux-musl-x64, linux-arm, linux-arm64, win-x64, win-x86, win-arm, win-arm64, osx-x64, osx-arm64]
+        runtime: [linux-x64, linux-musl-x64, linux-arm, linux-arm64, win-x64, win-x86, win-arm64, osx-x64, osx-arm64]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-dotnet@v3.0.2
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '8.0'
 
       - name: Build
         run: dotnet build src/cyclonedx/cyclonedx.csproj -r ${{ matrix.runtime }}
 
   # Fail if there are any failed tests
   #
-  # We support .NET 6.0 on Windows, Mac and Linux.
+  # We support .NET 8.0 on Windows, Mac and Linux.
   #
   # To check for failing tests locally run `dotnet test`.
   test:
@@ -61,7 +61,7 @@ jobs:
     - uses: actions/checkout@v3.1.0
     - uses: actions/setup-dotnet@v3.0.2
       with:
-        dotnet-version: '6.0'
+        dotnet-version: '8.0'
 
     - name: SnapshooterHotfixSymlinkLinux    
       if: matrix.os == 'ubuntu-latest'
@@ -75,4 +75,4 @@ jobs:
     - name: Tests
       run: |
         dotnet restore
-        dotnet test --framework net6.0
+        dotnet test --framework net8.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-dotnet@v3.0.2
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '8.0'
       - name: SnapshooterHotfixSymlinkLinux    
         run: sudo ln -s "$GITHUB_WORKSPACE" /_
         shell: bash
@@ -54,7 +54,7 @@ jobs:
           REPO=cyclonedx/cyclonedx-cli
           dotnet build --configuration Release
           mkdir bin
-          for runtime in linux-x64 linux-musl-x64 linux-arm linux-arm64 win-x64 win-x86 win-arm win-arm64 osx-x64
+          for runtime in linux-x64 linux-musl-x64 linux-arm linux-arm64 win-x64 win-x86 win-arm64 osx-x64
           do
             dotnet publish src/cyclonedx/cyclonedx.csproj -r $runtime --configuration Release /p:Version=$VERSION --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesInSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true --output bin/$runtime
           done
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-dotnet@v3.0.2
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '8.0'
 
       - name: Create binary
         run: |

--- a/README.md
+++ b/README.md
@@ -333,7 +333,6 @@ Officially supported builds are available for these platforms:
 Community supported builds are available for these platforms:
 
 - Windows x86 (win-x86)
-- Windows ARM (win-arm)
 - Windows ARM x64 (win-arm64)
 - Linux ARM (linux-arm)
 - Linux ARM x64 (linux-arm64)
@@ -388,7 +387,7 @@ Permission to modify and redistribute is granted under the terms of the Apache 2
 Pull requests are welcome. But please read the
 [CycloneDX contributing guidelines](https://github.com/CycloneDX/.github/blob/master/CONTRIBUTING.md) first.
 
-To build and test the solution locally you should have .NET 6
+To build and test the solution locally you should have .NET 8
 installed. Standard commands like `dotnet build` and `dotnet test` work.
 
 It is generally expected that pull requests will include relevant tests.

--- a/src/cyclonedx/Commands/KeyGenCommand.cs
+++ b/src/cyclonedx/Commands/KeyGenCommand.cs
@@ -37,7 +37,7 @@ namespace CycloneDX.Cli.Commands
         public static async Task<int> KeyGen(KeyGenCommandOptions options)
         {
             Console.WriteLine("Generating new public/private key pair...");
-            using (RSA rsa = new RSACryptoServiceProvider(2048))
+            using (var rsa = new RSACryptoServiceProvider(2048))
             {
                 var publicKeyFilename = string.IsNullOrEmpty(options.PublicKeyFile) ? "public.key" : options.PublicKeyFile;
                 Console.WriteLine($"Saving public key to {publicKeyFilename}");

--- a/src/cyclonedx/Serialization/CsvSerializer.cs
+++ b/src/cyclonedx/Serialization/CsvSerializer.cs
@@ -61,7 +61,7 @@ namespace CycloneDX.Cli.Serialization
                     csv.WriteField("SwidTextEncoding");
                     csv.WriteField("SwidTextContent");
                     csv.WriteField("SwidUrl");
-                    var hashAlgorithms = Enum.GetValues(typeof(Hash.HashAlgorithm)).Cast<Hash.HashAlgorithm>();
+                    var hashAlgorithms = Enum.GetValues(typeof(Hash.HashAlgorithm)).Cast<Hash.HashAlgorithm>().ToList();
                     foreach (var hashAlgorithm in hashAlgorithms)
                     {
                         if (hashAlgorithm != Hash.HashAlgorithm.Null)
@@ -221,7 +221,7 @@ namespace CycloneDX.Cli.Serialization
                             if (!string.IsNullOrEmpty(hash.Content)) hashes.Add(hash);
                         }
                     }
-                    if (hashes.Any()) component.Hashes = hashes;
+                    if (hashes.Count != 0) component.Hashes = hashes;
 
                     var componentLicenses = new List<LicenseChoice>();
                     var licenseExpressions = csvReader.GetField("LicenseExpressions")?.Split(',');
@@ -261,7 +261,7 @@ namespace CycloneDX.Cli.Serialization
                             }
                         });
                     }
-                    if (componentLicenses.Any()) component.Licenses = componentLicenses;
+                    if (componentLicenses.Count != 0) component.Licenses = componentLicenses;
 
                     bom.Components.Add(component);
                 }

--- a/src/cyclonedx/cyclonedx.csproj
+++ b/src/cyclonedx/cyclonedx.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 <!--    <PublishTrimmed>true</PublishTrimmed>-->
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <RuntimeIdentifiers>linux-x64;linux-musl-x64;linux-arm;linux-arm64;win-x64;win-x86;win-arm;win-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>linux-x64;linux-musl-x64;linux-arm;linux-arm64;win-x64;win-x86;win-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/cyclonedx.tests/cyclonedx.tests.csproj
+++ b/tests/cyclonedx.tests/cyclonedx.tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <!-- <AnalysisMode>AllEnabledByDefault</AnalysisMode> -->
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
.NET 6 is no longer supported.
We thus need to drop also Windows ARM32 support (compare https://github.com/dotnet/aspnetcore/issues/50791).

Closes: https://github.com/CycloneDX/cyclonedx-cli/issues/416