### PR TITLE
Ignore case of file ending for validate command

### DIFF
--- a/src/cyclonedx/Commands/ValidateCommand.cs
+++ b/src/cyclonedx/Commands/ValidateCommand.cs
@@ -156,11 +156,11 @@ namespace CycloneDX.Cli.Commands
         {
             if (options.InputFormat == ValidationBomFormat.autodetect && !string.IsNullOrEmpty(options.InputFile))
             {
-                if (options.InputFile.EndsWith(".json", StringComparison.InvariantCulture))
+                if (options.InputFile.EndsWith(".json", StringComparison.InvariantCultureIgnoreCase))
                 {
                     options.InputFormat = ValidationBomFormat.json;
                 }
-                else if (options.InputFile.EndsWith(".xml", StringComparison.InvariantCulture))
+                else if (options.InputFile.EndsWith(".xml", StringComparison.InvariantCultureIgnoreCase))
                 {
                     options.InputFormat = ValidationBomFormat.xml;
                 }


### PR DESCRIPTION
Addresses one of the issues in https://github.com/CycloneDX/cyclonedx-cli/issues/447